### PR TITLE
Fix pre commit file-not-found error handling

### DIFF
--- a/utils/githooks/pre-commit.py
+++ b/utils/githooks/pre-commit.py
@@ -21,10 +21,10 @@ try:
                 print(f"Datetimestamping with datetime {datetime_string}: {html_filename}")
                 html_file.write(re.sub(r"<datetimestamp>.*</datetimestamp>", f"<datetimestamp>{datetime_string}</datetimestamp>", html))
         
-        except Exception as FileNotFoundError:
+        except FileNotFoundError:
             print(f"Datetimestamping: {html_filename} does not exist anymore (may be deleted?)")
 
 except Exception as e:
     print("Datetimestamping ERROR! Failed due to: ", e)
     print(35*'-',' ABORT ', 35*'-')
-    exit
+    exit(1)


### PR DESCRIPTION
## Summary
- handle FileNotFoundError correctly in pre-commit hook
- exit nonzero when datetimestamping fails

## Testing
- `python3 -m py_compile utils/githooks/pre-commit.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd61a65308330944145ab642ad94a